### PR TITLE
new certificates, client config files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,7 @@
 
 # Generated keys are saved locally, in what directory do you want to save these files?
 openvpn_local_key_directory: /tmp
+
+# List of vpn client certificate extensions
+client_extensions:
+  - "extendedKeyUsage = clientAuth"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,3 @@ galaxy_info:
   galaxy_tags:
     - openvpn
     - centos
-
-dependencies:
-  - robertdebock.ca

--- a/tasks/fetch_client_config.yml
+++ b/tasks/fetch_client_config.yml
@@ -1,0 +1,30 @@
+---
+
+- name: copy keys to publication directory
+  copy:
+    remote_src: yes
+    src: "{{ ca_openssl_path }}/subject_keys/{{ item.name }}.pem"
+    dest: "{{ ca_publication_location }}/{{ item.name }}.pem"
+  loop: "{{ openvpn_clients }}"
+
+- name: copy config files to publication directory
+  copy:
+    remote_src: yes
+    src: "{{ openvpn_config_directory }}/{{ item.name }}.ovpn"
+    dest: "{{ ca_publication_location }}/{{ item.name }}.ovpn"
+  loop: "{{ openvpn_clients }}"
+
+- name: create tarballs
+  archive:
+    path:
+      - "{{ ca_publication_location }}/{{ item.name }}.pem"
+      - "{{ ca_publication_location }}/{{ item.name }}.crt"
+      - "{{ ca_publication_location }}/{{ item.name }}.ovpn"
+    dest: "{{ ca_publication_location }}/{{ item.name }}.tgz"
+  loop: "{{ openvpn_clients }}"
+
+- name: fetch tarballs
+  fetch:
+    src: "{{ ca_publication_location }}/{{ item.name }}.tgz"
+    dest: "{{ openvpn_fetch_client_config_to }}"
+  loop: "{{ openvpn_clients }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,14 +8,57 @@
     name: "{{ openvpn_packages }}"
     state: present
 
+- name: ensure openvpn config directory exists
+  file:
+    path: "{{ item }}"
+    state: directory
+    recurse: yes
+  loop:
+    - "{{ openvpn_config_directory }}/private"
+    - "{{ openvpn_config_directory }}/certs"
+
+- name: set server certificate parameters
+  set_fact:
+    ca_requests:
+      - name: server
+        extensions:
+          - "extendedKeyUsage = serverAuth"
+  when:
+    - openvpn_server is defined
+
 - block:
-    - name: include ca role
-      include_role:
-        name: robertdebock.ca
-      vars:
-        ca_openssl_path: "{{ openvpn_certs_directory }}"
-        ca_requests:
-          - name: server
+    - name: configure openvpn client
+      template:
+        src: "{{ openvpn_client_config_file }}.j2"
+        dest: "{{ openvpn_config_directory }}/{{ openvpn_client_config_file }}"
+
+    - name: add clients to certificate requests list
+      set_fact:
+        ca_requests: "{{ ca_requests + [ item | combine({ 'extensions': ['extendedKeyUsage = clientAuth'] }) ] }}"
+      loop: "{{ openvpn_clients }}"
+
+  when:
+    - openvpn_clients is defined
+
+- name: generate keys and certificates (include ca role)
+  include_role:
+    name: robertdebock.ca
+
+- block:
+    - name: copy server key to config directory
+      copy:
+        remote_src: yes
+        src: "{{ ca_openssl_path }}/subject_keys/server.pem"
+        dest: "{{ openvpn_config_directory }}/private/server.pem" 
+
+    - name: copy server and ca certificates to config directory
+      copy:
+        remote_src: yes
+        src: "{{ ca_openssl_path }}/certs/{{ item }}"
+        dest: "{{ openvpn_config_directory }}/certs/{{ item }}"
+      loop:
+        - ca.crt
+        - server.crt
 
     - name: generate static encryption key
       command: openvpn --genkey --secret {{ openvpn_static_encryption_key }}
@@ -50,14 +93,6 @@
   when:
     - openvpn_server is defined
     - openvpn_server | bool
-
-- name: configure openvpn client
-  template:
-    src: "{{ openvpn_client_config_file }}.j2"
-    dest: "{{ openvpn_config_directory }}/{{ openvpn_client_config_file }}"
-  when:
-    - openvpn_client is defined
-    - openvpn_client | bool
 
 - name: start and enable openvpn server
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,11 +30,12 @@
     - name: configure openvpn client
       template:
         src: "{{ openvpn_client_config_file }}.j2"
-        dest: "{{ openvpn_config_directory }}/{{ openvpn_client_config_file }}"
+        dest: "{{ openvpn_config_directory }}/{{ item.name }}.ovpn"
+      loop: "{{ openvpn_clients }}"
 
     - name: add clients to certificate requests list
       set_fact:
-        ca_requests: "{{ ca_requests + [ item | combine({ 'extensions': ['extendedKeyUsage = clientAuth'] }) ] }}"
+        ca_requests: "{{ ca_requests + [ item | combine({ 'extensions': client_extensions }) ] }}"
       loop: "{{ openvpn_clients }}"
 
   when:
@@ -43,6 +44,12 @@
 - name: generate keys and certificates (include ca role)
   include_role:
     name: robertdebock.ca
+
+- name: fetch client config tarball
+  include_tasks: fetch_client_config.yml
+  when:
+    - openvpn_clients is defined
+    - openvpn_fetch_client_config_to is defined  
 
 - block:
     - name: copy server key to config directory

--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -4,7 +4,7 @@ ca {{ openvpn_config_directory }}/certs/ca.crt
 cert {{ openvpn_config_directory }}/certs/client.crt
 key {{ openvpn_config_directory }}/private/client.key
 tls-crypt {{ openvpn_static_encryption_key }}
-remote-cert-eku "TLS Web Client Authentication"
+remote-cert-eku "TLS Web Server Authentication"
 proto udp
 remote {{ openvpn_client_server }} 1194 udp
 dev tun

--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -1,8 +1,8 @@
 client
 tls-client
 ca {{ openvpn_config_directory }}/certs/ca.crt
-cert {{ openvpn_config_directory }}/certs/client.crt
-key {{ openvpn_config_directory }}/private/client.key
+cert {{ openvpn_config_directory }}/certs/{{ item.name }}.crt
+key {{ openvpn_config_directory }}/private/{{ item.name }}.key
 tls-crypt {{ openvpn_static_encryption_key }}
 remote-cert-eku "TLS Web Server Authentication"
 proto udp


### PR DESCRIPTION
---
name: Pull request by grzs
about: certificates, client config files

---

**Describe the change**
The role now uses the new features of ca role. The certificates are signed by the CA, and build the proper extensions.
I added a new feature: if a local path set, the role fetches the client config file, key and certificate in a tarball. 

**Testing**
Tested on a DigitalOcean droplet with the following playbook:

```yaml
---
- name: install openvpn server
  hosts: vpn
  become: yes
  gather_facts: yes
  vars:
    - ca_openssl_path: "/etc/ssl/myCA"

  roles:
    - role: robertdebock.openvpn
      vars:
        openvpn_server: yes
        openvpn_client_server: "{{ ansible_host }}"
        openvpn_fetch_client_config_to: ~/tmp
        openvpn_clients:
          - name: vpn-client
```
